### PR TITLE
Fix "new document" button for non-localhost deployments

### DIFF
--- a/draw.html
+++ b/draw.html
@@ -69,7 +69,7 @@
 
         <div class="border-top"></div>
 
-        <button class="tool" onclick="window.open('http://127.0.0.1:5502/draw.html', '_blank');">
+        <button class="tool" onclick="window.open(window.location.href, '_blank');">
             <i class="fa-solid fa-square-plus"></i>
         </button>
 


### PR DESCRIPTION
Previously, the website used a hardcoded URL to redirect the user to, now, it uses JavaScript to duplicate the current tab.